### PR TITLE
Add default zip code to load upon website first view

### DIFF
--- a/script.js
+++ b/script.js
@@ -74,9 +74,12 @@ function spotifySearch() {
     }); 
 };
 
-//// ON INITIAL PAGE LOAD, DISPLAY WEATHER AND TRACKS FOR MOST RECENTLY SEARCHED ZIP CODE (SAVED IN LOCAL STORAGE)
+//// ON INITIAL PAGE LOAD, DISPLAY WEATHER AND TRACKS FOR MOST RECENTLY SEARCHED ZIP CODE (SAVED IN LOCAL STORAGE) OR FOR 48824 IF NONE SAVED
 if (searchHistory){
   zipCode = localStorage.getItem('searchHistory');
+  fetchWeather(zipCode);
+} else {
+  zipCode = 48824;
   fetchWeather(zipCode);
 };
 


### PR DESCRIPTION
Set default zip code to 48824 to load upon 1st page load when no zip is in local storeage.